### PR TITLE
Bump color-alpha at 1.0.4 - module regl-splom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,11 +173,23 @@
       "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
     },
     "color-alpha": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.3.tgz",
-      "integrity": "sha512-ap5UCPpnpsSQu09ccl/5cNQDJlSFvkuXHMBY1+1vu6iKj6H9zw7Sz852snsETFsrYlPUnvTByCFAnYVynKJb9A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "requires": {
-        "color-parse": "^1.2.0"
+        "color-parse": "^1.3.8"
+      },
+      "dependencies": {
+        "color-parse": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+          "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
+          "requires": {
+            "color-name": "^1.0.0",
+            "defined": "^1.0.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        }
       }
     },
     "color-convert": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dy/regl-splom.git"
+    "url": "git+https://github.com/gl-vis/regl-splom.git"
   },
   "keywords": [
     "regl",
@@ -32,9 +32,9 @@
   "author": "Dmitry Yv <df.creative@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dy/regl-splom/issues"
+    "url": "https://github.com/gl-vis/regl-splom/issues"
   },
-  "homepage": "https://github.com/dy/regl-splom#readme",
+  "homepage": "https://github.com/gl-vis/regl-splom#readme",
   "dependencies": {
     "array-bounds": "^1.0.1",
     "array-range": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "array-bounds": "^1.0.1",
     "array-range": "^1.0.1",
     "bubleify": "^1.2.0",
-    "color-alpha": "^1.0.3",
+    "color-alpha": "^1.0.4",
     "defined": "^1.0.0",
     "flatten-vertex-data": "^1.0.2",
     "left-pad": "^1.3.0",


### PR DESCRIPTION
Include fix for https://github.com/colorjs/color-parse/issues/1
@dy 
cc: @etpinard