### PR TITLE
dependencies: Remove left-pad; move bubleify, defined, point-cluster to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,23 +38,23 @@
   "dependencies": {
     "array-bounds": "^1.0.1",
     "array-range": "^1.0.1",
-    "bubleify": "^2.0.0",
     "color-alpha": "^1.0.4",
-    "defined": "^1.0.0",
     "flatten-vertex-data": "^1.0.2",
     "parse-rect": "^1.2.0",
     "pick-by-alias": "^1.2.0",
-    "point-cluster": "^3.1.8",
     "raf": "^3.4.1",
     "regl-scatter2d": "^3.1.2"
   },
   "devDependencies": {
+    "bubleify": "^2.0.0",
     "chttps": "^1.0.6",
+    "defined": "^1.0.0",
     "fps-indicator": "^1.3.0",
     "gauss-random": "^1.0.1",
     "glslify": "^7.0.0",
     "nice-color-palettes": "^2.0.0",
     "pan-zoom": "^3.4.0",
+    "point-cluster": "^3.1.8",
     "regl": "^1.3.11",
     "settings-panel": "^1.8.17"
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "color-alpha": "^1.0.4",
     "defined": "^1.0.0",
     "flatten-vertex-data": "^1.0.2",
-    "left-pad": "^1.3.0",
     "parse-rect": "^1.2.0",
     "pick-by-alias": "^1.2.0",
     "point-cluster": "^3.1.8",


### PR DESCRIPTION
`left-pad` is unused since commit c6d064ebc546ed71c48d8c5b7e66cfe0980ef77a.

`bubleify`, `defined`, `point-cluster` are only used for `index.html`, which is not part of the NPM package.

Fixes #13.